### PR TITLE
fix(jenkins): run quality gate in-cluster (Option A)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,15 +2,13 @@
 // Flow: Resolve release -> Quality gate -> Fetch source -> Build & Publish -> (notify on failure)
 // Governed by .specify/memory/constitution.md (Principles I-V).
 //
-// Runs on the `unraid-docker` permanent agent (label `docker`) because the build
-// needs a REAL Docker daemon: buildx multi-arch + QEMU emulation are not possible
-// on the daemonless kaniko k8s agents.
-//
-// NOTE on SonarQube: the cluster's `SonarQube` JCasC installation points at the
-// in-cluster URL (sonarqube-sonarqube.sonarqube:9000), which the off-cluster
-// unraid-docker VM cannot reach. Use a public-URL installation instead — set
-// SONARQUBE_INSTALLATION (defaults to `SonarQube-Public`, which must be added to
-// the JCasC sonarGlobalConfiguration pointing at https://sonarqube.taylorcohron.me).
+// Split agents:
+//   * Most stages run on the `unraid-docker` permanent node (label `docker`) — a
+//     REAL Docker daemon is required for buildx multi-arch + QEMU + docker run,
+//     which the daemonless kaniko agents cannot do.
+//   * The Quality gate runs IN-CLUSTER on the `sonar` pod (sonar-scanner-cli),
+//     reaching SonarQube over the internal service URL — the off-cluster VM
+//     cannot pass the Cloudflare Access edge in front of the public URL.
 
 pipeline {
   agent { label 'docker' }
@@ -41,17 +39,11 @@ pipeline {
     GHCR_OWNER          = "${env.GHCR_OWNER ?: 'untraceablez'}"
     WORK_DIR            = '.work'
 
-    // usernamePassword credentials -> _USR / _PSW (add these IDs to JCasC).
+    // usernamePassword credentials -> _USR / _PSW (defined in JCasC).
     DOCKERHUB_CREDS = credentials('dockerhub-token')
     GHCR_CREDS      = credentials('ghcr-token')
 
-    // Which JCasC SonarQube installation to use (must be reachable from this agent).
-    SONARQUBE_INSTALLATION = "${env.SONARQUBE_INSTALLATION ?: 'SonarQube-Public'}"
-
     NOTIFY_EMAIL = "${env.NOTIFY_EMAIL ?: 'taylorcohrontech@gmail.com'}"
-    // GITHUB_TOKEN is optional; if a 'github-token' secret-text credential exists,
-    // bind it in a script block per-stage. Unset is fine (unauthenticated release
-    // reads are well within the hourly-poll rate limit).
   }
 
   stages {
@@ -92,12 +84,14 @@ pipeline {
 
     stage('Quality gate') {
       when { expression { env.ACTION == 'build' } }
+      // Run in-cluster: the sonar-scanner-cli pod reaches SonarQube on the internal
+      // service URL (withSonarQubeEnv('SonarQube')), sidestepping Cloudflare Access.
+      agent { label 'sonar' }
       steps {
-        // FR-012: scan this repo's own artifacts; block publish on failure.
-        // withSonarQubeEnv injects SONAR_HOST_URL + SONAR_AUTH_TOKEN for the chosen
-        // installation and wires the report-task correlation for waitForQualityGate.
-        withSonarQubeEnv("${env.SONARQUBE_INSTALLATION}") {
-          sh 'scripts/quality-gate.sh'
+        container('sonar-scanner') {
+          withSonarQubeEnv('SonarQube') {
+            sh 'scripts/quality-gate.sh'
+          }
         }
         timeout(time: 10, unit: 'MINUTES') {
           waitForQualityGate abortPipeline: true
@@ -131,6 +125,7 @@ pipeline {
 
   post {
     failure {
+      // Runs on the pipeline's default `docker` agent (workspace + scripts present).
       sh '''
         scripts/notify.sh "${VERSION:-unknown}" "${STAGE_NAME:-pipeline}" "${BUILD_URL:-n/a}" "See Jenkins log"
       '''

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -19,8 +19,10 @@
 
 set -eu
 
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_ROOT="${REPO_ROOT:-$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)}"
+# Neutralize CDPATH so `cd` never echoes a resolved path into the substitution.
+CDPATH=''
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/.." && pwd)}"
 REPORT="${REPO_ROOT}/shellcheck-report.json"
 
 log() { printf '[quality-gate] %s\n' "$*" >&2; }

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -1,68 +1,66 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # quality-gate.sh - run the SonarQube quality analysis over THIS repository's
 # own artifacts (FR-012/017; Principle V).
 #
+# POSIX sh (NOT bash): this runs inside the Alpine sonarsource/sonar-scanner-cli
+# container on an in-cluster Jenkins agent, which has no bash. Avoid arrays,
+# mapfile, [[ ]], and other bashisms.
+#
 # Steps:
-#   1. Run ShellCheck over scripts/** producing a SonarQube "generic issue"
-#      JSON report (imported via sonar.externalIssuesReportPaths in
-#      sonar-project.properties), since SonarQube has limited native shell
-#      support.
-#   2. Invoke sonar-scanner over the repo (scope limited by
-#      sonar-project.properties to our scripts/pipeline — never upstream).
+#   1. If ShellCheck + jq are available, emit a SonarQube generic-issue report
+#      from ShellCheck over scripts/** (imported via sonar.externalIssuesReportPaths).
+#      The in-cluster scanner image has neither, so an empty (but valid) report is
+#      written instead — shell linting is enforced separately by GitHub Actions.
+#   2. Run sonar-scanner (scope limited by sonar-project.properties to our own
+#      scripts/pipeline — never upstream). PASS/FAIL is enforced by the pipeline's
+#      waitForQualityGate after this reports to the server.
 #
-# The actual PASS/FAIL enforcement happens in the Jenkinsfile via
-# `waitForQualityGate` after this scanner run reports to the server. This
-# script fails (non-zero) only if the scanner itself cannot run.
-#
-# Config: SONAR_HOST_URL, SONAR_TOKEN
+# Config: SONAR_HOST_URL + SONAR_TOKEN|SONAR_AUTH_TOKEN (injected by withSonarQubeEnv).
 
-set -euo pipefail
+set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# shellcheck source=scripts/lib/common.sh
-. "${SCRIPT_DIR}/lib/common.sh"
-
-REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT="${REPO_ROOT:-$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)}"
 REPORT="${REPO_ROOT}/shellcheck-report.json"
 
-require_cmd shellcheck jq
+log() { printf '[quality-gate] %s\n' "$*" >&2; }
+die() { printf '[quality-gate] ERROR: %s\n' "$*" >&2; exit 1; }
 
-# --- 1. ShellCheck -> SonarQube generic issue format ------------------------
-mapfile -t SH_FILES < <(find "${REPO_ROOT}/scripts" -name '*.sh' -type f)
-if [ "${#SH_FILES[@]}" -eq 0 ]; then
-  warn "no shell scripts found under scripts/"
-  printf '{"rules":[],"issues":[]}\n' > "$REPORT"
+# --- 1. ShellCheck -> SonarQube generic issue report (best-effort) ----------
+if command -v shellcheck >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  files=$(find "${REPO_ROOT}/scripts" -name '*.sh' -type f 2>/dev/null || true)
+  if [ -n "$files" ]; then
+    log "running ShellCheck over scripts/**"
+    # shellcheck disable=SC2086 # intentional word-splitting; our paths have no spaces
+    sc_json=$(shellcheck -x -f json1 $files 2>/dev/null || true)
+    printf '%s' "$sc_json" | jq '{
+      rules: [ .comments[] | {id: ("SC" + (.code|tostring)), name: ("ShellCheck SC" + (.code|tostring)),
+               engineId: "shellcheck", cleanCodeAttribute: "LOGICAL",
+               impacts: [ {softwareQuality: "RELIABILITY",
+                 severity: (if .level=="error" then "HIGH" elif .level=="warning" then "MEDIUM" else "LOW" end)} ] } ]
+             | unique_by(.id),
+      issues: [ .comments[] | {
+               ruleId: ("SC" + (.code|tostring)),
+               primaryLocation: {
+                 message: .message,
+                 filePath: .file,
+                 textRange: {startLine: .line, endLine: (.endLine // .line)}
+               } } ]
+    }' > "$REPORT"
+    log "ShellCheck report: $(jq '.issues|length' "$REPORT") issue(s)"
+  else
+    printf '%s' '{"rules":[],"issues":[]}' > "$REPORT"
+  fi
 else
-  log "running ShellCheck over ${#SH_FILES[@]} script(s)"
-  # ShellCheck JSON1 -> SonarQube generic external issues.
-  # Severity map: error->BLOCKER, warning->MAJOR, info/style->MINOR.
-  sc_json="$(shellcheck -x -f json1 "${SH_FILES[@]}" || true)"
-  printf '%s' "$sc_json" | jq '{
-    rules: [ .comments[] | {id: ("SC" + (.code|tostring)), name: ("ShellCheck SC" + (.code|tostring)),
-             engineId: "shellcheck", cleanCodeAttribute: "LOGICAL",
-             impacts: [ {softwareQuality: "RELIABILITY",
-               severity: (if .level=="error" then "HIGH" elif .level=="warning" then "MEDIUM" else "LOW" end)} ] } ]
-           | unique_by(.id),
-    issues: [ .comments[] | {
-             ruleId: ("SC" + (.code|tostring)),
-             primaryLocation: {
-               message: .message,
-               filePath: .file,
-               textRange: {startLine: .line, endLine: (.endLine // .line)}
-             }
-           } ]
-  }' > "$REPORT"
-  log "ShellCheck report written to ${REPORT} ($(jq '.issues|length' "$REPORT") issue(s))"
+  log "shellcheck/jq unavailable (expected in the scanner container) — writing empty external-issues report; shell lint is gated by GitHub Actions"
+  printf '%s' '{"rules":[],"issues":[]}' > "$REPORT"
 fi
 
 # --- 2. sonar-scanner -------------------------------------------------------
-# withSonarQubeEnv injects SONAR_HOST_URL and SONAR_AUTH_TOKEN; accept either
-# token name.
+# withSonarQubeEnv injects SONAR_HOST_URL and SONAR_AUTH_TOKEN; accept either name.
 SONAR_TOKEN="${SONAR_TOKEN:-${SONAR_AUTH_TOKEN:-}}"
 [ -n "${SONAR_HOST_URL:-}" ] || die "SONAR_HOST_URL not set (run inside withSonarQubeEnv, or export it)"
 [ -n "${SONAR_TOKEN}" ]      || die "SONAR token not set (SONAR_TOKEN / SONAR_AUTH_TOKEN)"
-
-SCANNER_IMAGE="${SONAR_SCANNER_IMAGE:-sonarsource/sonar-scanner-cli:latest}"
 
 log "invoking sonar-scanner against ${SONAR_HOST_URL}"
 if command -v sonar-scanner >/dev/null 2>&1; then
@@ -70,15 +68,14 @@ if command -v sonar-scanner >/dev/null 2>&1; then
     -Dsonar.host.url="${SONAR_HOST_URL}" \
     -Dsonar.token="${SONAR_TOKEN}"
 elif command -v docker >/dev/null 2>&1; then
-  # No native scanner: run it in a container (the unraid-docker agent has Docker).
-  log "sonar-scanner binary absent; using container ${SCANNER_IMAGE}"
+  log "sonar-scanner binary absent; using container ${SONAR_SCANNER_IMAGE:-sonarsource/sonar-scanner-cli:latest}"
   docker run --rm \
     -e SONAR_HOST_URL="${SONAR_HOST_URL}" \
     -e SONAR_TOKEN="${SONAR_TOKEN}" \
     -v "${REPO_ROOT}:/usr/src" \
-    "${SCANNER_IMAGE}"
+    "${SONAR_SCANNER_IMAGE:-sonarsource/sonar-scanner-cli:latest}"
 else
-  die "no sonar-scanner binary and no docker available to run ${SCANNER_IMAGE}"
+  die "no sonar-scanner binary and no docker available"
 fi
 
 log "sonar-scanner completed; quality gate result is enforced by waitForQualityGate in the pipeline"


### PR DESCRIPTION
Follow-up to #6 (merged before this commit landed). Without this, `main`'s Jenkinsfile targets the off-cluster path that Cloudflare Access blocks.

## Why
SonarQube's public URL is behind **Cloudflare Access**, which the off-cluster `unraid-docker` VM can't pass (its token authenticates to SonarQube, not the Access edge). So the quality gate must run **in-cluster**, exactly how pantrie/scryme scan.

## What
- **Jenkinsfile**: split agents — pipeline default `docker` (unraid-docker), and the **Quality gate** stage overrides to `agent { label 'sonar' }` + `container('sonar-scanner')`, reaching SonarQube on the internal URL via `withSonarQubeEnv('SonarQube')`. Dropped the `SonarQube-Public` indirection.
- **quality-gate.sh**: rewritten as **POSIX sh** (the Alpine sonar-scanner-cli container has no bash — no arrays/`mapfile`). ShellCheck import is best-effort (writes a valid empty report when absent; shell lint is gated by GitHub Actions), scanner runs natively.

Pairs with urza-helm #183 (adds the `sonar` pod template, drops `SonarQube-Public`, installs `jq`/`curl` on the agent).

GitHub Actions `make check` (ShellCheck + bats) validates this PR. `quality-gate.sh` verified under `sh` and `dash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)