### PR TITLE
fix(jenkins): use only core pipeline steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,12 +73,12 @@ pipeline {
       steps {
         sh 'scripts/check-release.sh'
         script {
-          // Parse .work/decision.env with core steps only (no Pipeline Utility Steps
-          // plugin on this controller, so no readProperties).
-          readFile("${env.WORK_DIR}/decision.env").trim().split('\n').each { line ->
-            def kv = line.split('=', 2)
-            if (kv.length == 2) { env[kv[0].trim()] = kv[1].trim() }
-          }
+          // Read decision.env values with sandbox-safe steps only: sh(returnStdout)
+          // + fixed env assignments (no readProperties/readFile, no dynamic env[...]
+          // which the Groovy sandbox rejects as putAt).
+          env.ACTION    = sh(returnStdout: true, script: '. .work/decision.env; printf %s "$ACTION"').trim()
+          env.VERSION   = sh(returnStdout: true, script: '. .work/decision.env; printf %s "$VERSION"').trim()
+          env.IS_NEWEST = sh(returnStdout: true, script: '. .work/decision.env; printf %s "$IS_NEWEST"').trim()
           echo "Decision: action=${env.ACTION} version=${env.VERSION} is_newest=${env.IS_NEWEST}"
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,8 @@ pipeline {
   options {
     // Principle IV: single-flight so overlapping poll cycles cannot corrupt tags.
     disableConcurrentBuilds()
-    timestamps()
     timeout(time: 90, unit: 'MINUTES')
+    // (No timestamps() — the Timestamper plugin is not installed on this controller.)
   }
 
   // FR-009: poll the upstream releases on a schedule (default hourly).
@@ -73,10 +73,12 @@ pipeline {
       steps {
         sh 'scripts/check-release.sh'
         script {
-          def props = readProperties file: "${env.WORK_DIR}/decision.env"
-          env.ACTION     = props.ACTION
-          env.VERSION    = props.VERSION
-          env.IS_NEWEST  = props.IS_NEWEST
+          // Parse .work/decision.env with core steps only (no Pipeline Utility Steps
+          // plugin on this controller, so no readProperties).
+          readFile("${env.WORK_DIR}/decision.env").trim().split('\n').each { line ->
+            def kv = line.split('=', 2)
+            if (kv.length == 2) { env[kv[0].trim()] = kv[1].trim() }
+          }
           echo "Decision: action=${env.ACTION} version=${env.VERSION} is_newest=${env.IS_NEWEST}"
         }
       }


### PR DESCRIPTION
The first auto-triggered build failed to compile: the controller's pinned plugin set lacks **Timestamper** and **Pipeline Utility Steps**.

- Drop `options { timestamps() }`.
- Replace `readProperties` with a core `readFile` + parse of `.work/decision.env`.

No new plugins required (keeps the controller's minimal pinned set). GitHub Actions CI covers shell/bats; the Jenkinsfile itself is validated by an actual build (triggered post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)